### PR TITLE
Fix autoload-dev loading for PlainCommands\Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "autoload-dev": {
         "psr-4": {
             "PlainCommands\\Examples\\": "examples/src",
-            "PlainCommands\\Tests\\": "tests/src"
+            "PlainCommands\\Tests\\": "tests"
         },
         "files": [
             "vendor/phpunit/phpunit/src/Framework/Assert/Functions.php"


### PR DESCRIPTION
# Changed log

- It doesn't have the `src` folder on `tests` folder. It should use the `tests` on `autoload-dev` setting for `PlainCommands\\Tests\\` namespace to load test classes automatically.